### PR TITLE
Added Eject Step

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ git clone git@github.com:ethanneff/react-native-web-typescript.git
 cd react-native-typescript
 yarn install
 yarn rebuild
+react-native eject
 ```
 
 ### run


### PR DESCRIPTION
because rebuild deletes "ios" and "android" you will need to re-eject before you can build ios or android